### PR TITLE
Fix #4 by removing ANSI escape codes from perlcritic output

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -122,6 +122,8 @@ class Output {
 
 		outputStr.split(/\[\[END\]\]/).forEach((critiqueText: string, i: number) => {
 			critiqueText = critiqueText.trim();
+			// remove ANSI escape code
+			critiqueText = critiqueText.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, "");
 			let critique = new Critique(critiqueText);
 
 			if (critique.error) {


### PR DESCRIPTION
credit: regex pattern lifted from
https://stackoverflow.com/questions/25245716/remove-all-ansi-colors-styles-from-strings/29497680#29497680

Tested on a Mac with Perl v5.26.1 and perlcritic v1.130.

NOTE: I've tested the change locally, with Javascript code.
The Typescript code here is a straightforward port and should not cause troubles,
but please have a closer look just in case.