### PR TITLE
Fix #5 by conditionally applying the --severity option

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -71,7 +71,12 @@ class Settings {
 				return v;
 			}
 		});
-		this.options.push('--' + severity);
+		if (this.options.indexOf("--profile") === -1) {
+			// Only set severity if user does not specify a profile,
+			// because perlcritic will ignore the profile if severity is set.
+			// Tested on a Mac with perlcritic v1.130, Perl v5.26.1.
+			this.options.push('--' + severity);
+		}
 		this.options.push('--top=' + maxNumberOfProblems);
 	}
 }


### PR DESCRIPTION
Tested on a Mac with Perl v5.26.1 and perlcritic v1.130.

NOTE: I've tested the change locally, with Javascript code.
The Typescript code here is a straightforward port and should not cause troubles,
but please have a closer look just in case.