### PR TITLE
Fix for severity 1 warnings not displaying

### DIFF
--- a/server/src/Critique.ts
+++ b/server/src/Critique.ts
@@ -24,7 +24,7 @@ export default class Critique {
 
         this.line = lineInt > 0 ? lineInt - 1 : 0;
         this.column = columnInt > 0 ? columnInt - 1 : 0;
-        this.severity = severityInt > 0 ? severityInt - 1 : 0;
+        this.severity = severityInt > 0 ? severityInt : 0;
         this.summary = summaryStr.trim();
         this.explanation = explanationStr.trim();
         return;


### PR DESCRIPTION
Good day, our team have noticed that severity 1 warnings were not displayed.

We tracked it down to the Critique.ts file. I am not sure why the value is decremented, I suspect that may have been an oversight.

With this fix our severity 1 warnings now show up.

Regards 👍 