### PR TITLE
Fix condition of using severity config of extension

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -131,7 +131,7 @@ function mergeSettings(newSettings: PerlcriticSettings): PerlcriticSettings {
 	// Only set severity if user does not specify a profile,
 	// because perlcritic will ignore the profile if severity is set.
 	// Tested on a Mac with perlcritic v1.130, Perl v5.26.1.
-	if (newSettings.additionalArguments.indexOf("--profile") < 0 || newSettings.additionalArguments.indexOf("-p") < 0) {
+	if (newSettings.additionalArguments.indexOf("--profile") === -1 && newSettings.additionalArguments.indexOf("-p") === -1) {
 		newSettings.additionalArguments.push(`--${newSettings.severity}`);
 	}
 


### PR DESCRIPTION
I read the following comment and set `"perlcritic.additionalArguments": ["--profile", ".perlcriticrc"]` but severity config in `.perlcriticrc` was ignored.
https://github.com/sfodje/perlcritic/blob/a996ff488d69b3807b6bcb2c9b3c5a75726e130f/server/src/server.ts#L131-L133

I think the condition of using severity config from extension setting is wrong. The severity from extension setting is used unless both `--profile` and `-p` is in the additional arguments.
https://github.com/sfodje/perlcritic/blob/a996ff488d69b3807b6bcb2c9b3c5a75726e130f/server/src/server.ts#L134-L136