### PR TITLE
Suggestion: add policy name to diagnostic message

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -93,7 +93,7 @@ const defaultSettings: PerlcriticSettings = {
 	executable: validateExecutable("perlcritic"),
 	severity: "gentle",
 	onSave: false,
-	additionalArguments: ['--quiet', ["--verbose", "%l[>]%c[>]%s[>]%m. %e[>]%d[[END]]"].join('=')]
+	additionalArguments: ['--quiet', ["--verbose", "%l[>]%c[>]%s[>]%m. %e (%p)[>]%d[[END]]"].join('=')]
 };
 let globalSettings: PerlcriticSettings = defaultSettings;
 


### PR DESCRIPTION
# Summary

Showing policy name in diagnostic message is useful for:

- finding more information about the policy from metacpan.
- changing configuration for the policy with `.perlcriticrc` immediately.

# Screnshot

![image](https://user-images.githubusercontent.com/4530627/99237276-9735d080-283b-11eb-9b75-0989f4674171.png)
